### PR TITLE
ログイン、トップページに商品詳細を表示

### DIFF
--- a/app/assets/stylesheets/modules/index.scss
+++ b/app/assets/stylesheets/modules/index.scss
@@ -235,7 +235,7 @@
         display: flex;
         justify-content: space-around;
         &__list{
-          width: 220px;
+          //width: 220px;
           display: inline-block;
           float: left;
           &__img{

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,7 @@
 class HomesController < ApplicationController
   def index
+
+    @items = Item.where(trading_status: '出品中')
   end
 
 end

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -1,5 +1,5 @@
 %wrapper
-  =render  "shared/header"
+  =render "shared/header"
   .main
     .main__contents
       .main__contents__visual
@@ -87,37 +87,43 @@
           = link_to "#",class:"list"  do
             %h3 新規投稿商品
         .main__pickup__product__lists
-          .main__pickup__product__lists__list
-            =image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/18/beef.JPG", class:  "main__pickup__product__lists__list__img"
-            .main__pickup__product__lists__list__text
-              .main__pickup__product__lists__list__text__name
-                テスト
-              .main__pickup__product__lists__list__text__detail
-              %ul
-                %li 1000円
-                %li.fav
-                  %i.fas.fa-star 
-                  1
-              %p (税込)
+          - @items.each do |item|
+            .main__pickup__product__lists
+              .main__pickup__product__lists__list
+              = link_to item_path(item.id) do
+                = image_tag "#{item.item_images[0].src}" ,class: "main__pickup__product__lists__list__img"
+                .main__pickup__product__lists__list__text
+                  .main__pickup__product__lists__list__text__name
+                  = item.name
+                  .main__pickup__product__lists__list__text__detail
+                  %ul
+                    %li= ('¥' + item.price.to_s(:delimited))
+                    %li.fav
+                      %i.fas.fa-star 
+                      1
+                  %p (税込)
       .main__pickup__head
         ピックアップブランド
       .main__pickup__product
         .main__pickup__product__head
-          = link_to "#",class:"list"  do
+          = link_to "#",class:"list" do
             %h3 アーカイバ
         .main__pickup__product__lists
-          .main__pickup__product__lists__list
-            =image_tag  "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/18/beef.JPG", class:  "main__pickup__product__lists__list__img"
-            .main__pickup__product__lists__list__text
-              .main__pickup__product__lists__list__text__name
-                テスト
-              .main__pickup__product__lists__list__text__detail
-              %ul
-                %li 1000円
-                %li.fav
-                  %i.fas.fa-star 
-                  1
-              %p (税込)
+          - @items.each do |item|
+            .main__pickup__product__lists
+              .main__pickup__product__lists__list
+              = link_to item_path(item.id) do
+                = image_tag "#{item.item_images[0].src}" ,class: "main__pickup__product__lists__list__img"
+                .main__pickup__product__lists__list__text
+                  .main__pickup__product__lists__list__text__name
+                  = item.name
+                  .main__pickup__product__lists__list__text__detail
+                  %ul
+                    %li= ('¥' + item.price.to_s(:delimited))
+                    %li.fav
+                      %i.fas.fa-star 
+                      1
+                  %p (税込)
 
 
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -14,9 +14,7 @@
           = link_to "カテゴリー", "#", id: "catBtn"
           .category_list
             .parents_list
-              -# jquery導入後hover表示
-              -# - @parents.each do |parent|
-              -#   = link_to "#{parent.name}", category_path(parent), class: "parent_category",id: "#{parent.id}"
+
             .children_list
               
             .grand_children_list
@@ -26,9 +24,11 @@
       %ul.listsFrameRight
 
         %li.listsFrameRight__item
-          = link_to "ログアウト", destroy_user_session_path
-          = link_to "マイページ", "#"
-        %li.listsFrameRight__item
-          = link_to "ログイン", new_user_session_path
-        %li.listsFrameRight__item.listsFrameRight__item--new
-          = link_to "新規会員登録", "#"
+        - if user_signed_in?
+          = link_to "ログアウト", destroy_user_session_path, method: :delete
+          = link_to "マイページ", users_path
+        - else
+          %li.listsFrameRight__item
+            = link_to "ログイン", new_user_session_path
+          %li.listsFrameRight__item.listsFrameRight__item--new
+            = link_to "新規会員登録",  new_user_registration_path

--- a/app/views/users/_mypage-side.html.haml
+++ b/app/views/users/_mypage-side.html.haml
@@ -38,7 +38,7 @@
   %h3 ログアウト
   %ul.nav-bottom
     %li
-      = link_to 'ログアウト', ""
+      = link_to "ログアウト", destroy_user_session_path, method: :delete
       = icon('fa', 'angle-right', class: "icon-possition")
 
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -12,7 +12,7 @@
           .right-top__bg-mask--avatar
           .right-top__bg-mask--nickname
             %p
-              -#デバイスcurrent.user記入
+            -# = @user.nickname
       .preface
         = form_tag "#" do
           %textarea


### PR DESCRIPTION
# what
ログインログアウトのトップページヘッダー部分の条件分岐
出品された商品はトップページで一覧表示されるようにする
ログアウト状態でもトップページから商品詳細ページに飛べるようにする

# why
ログアウト機能を付け加える必要があったから
またログイン時にヘッダーの表示の切替えをする必要があったから
トップページに商品詳細を表示する必要があったから