### PR TITLE
新規会員登録修正

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,8 +1,6 @@
 class Address < ApplicationRecord
-  validates :postal_code ,null: false
-  validates :prefcture ,null: false
-  validates :city ,null: false
-  validates :house_number ,null: false
+  validates :postal_code, format: { with: /\A\d{3}[-]\d{4}\z/, multiline: true}
+  validates :postal_code,:prefecture,:city, :house_number, presence: true
   # validates :user_id ,null: false
   belongs_to :user
   enum prefecture:{

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,4 @@
 class Address < ApplicationRecord
-  validates :postal_code, format: { with: /\A\d{3}[-]\d{4}\z/, multiline: true}
   validates :postal_code,:prefecture,:city, :house_number, presence: true
   # validates :user_id ,null: false
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   # validates :bairthday, numericality:{ only_integer: true }
   validates :bairthday,presence: true
 
+
   has_one :address
   has_many  :items
 end

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -34,6 +34,11 @@
             %span.form-group__require 必須
             = f.password_field :password,{autocomplete: "new-password",placeholder: "7文字以上の半角英数字",class:'form-group__text',id:"password"}
             %p.form-group__info ※ 英字と数字の両方を含めて設定してください
+          .form-group
+            = f.label :確認用パスワード
+            %span.form-group__require 必須
+            = f.password_field :password,{autocomplete: "new-password",placeholder: "7文字以上の半角英数字",class:'form-group__text',id:"password"}
+            %p.form-group__info ※ 上記と同じ物を入力してください
           .form-password-revelation-toggle
             .checkbox-default
               %input#reveal_password{type: "checkbox",class:"icon-check"}


### PR DESCRIPTION
trelloの要件に「パスワードは確認用を含めて2回入力する」とあるので、パスワード確認欄の追加もお願いいたします。
▶︎修正済、動作確認ok
・新規会員登録の2枚目の住所入力で、何も入力しなくても会員登録ができます。バリデーションの設定をお願いいたします。
▶︎バリデーション編集ok
動作確認ok